### PR TITLE
Enable dev build to cut down on webpack resource usage.

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -53,7 +53,7 @@ def build(ctx, env_name=env_name, kernel=True):
         jupyter labextension install @jupyterlab/plotly-extension@0.17 --no-build &&
         jupyter labextension install @jupyter-widgets/jupyterlab-manager@0.36 --no-build &&
         jupyter labextension install bqplot@0.4.0 --no-build &&
-        jupyter lab clean && jupyter lab build
+        jupyter lab clean && jupyter lab build --dev
         """.format(source, env_name).strip().replace('\n', ''))
     if kernel:
         ctx.run("{0!s} activate {1!s} && ipython kernel install --name {1!s} --display-name {1!s} --sys-prefix".format(source, env_name))


### PR DESCRIPTION
Band-aid for #74. By not uglifying the build we significantly cut down on resource usage in the demo docker images.