### PR TITLE
Update xtensor-blas and scikit-learn versions

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -17,7 +17,7 @@ dependencies:
 - pandas=0.20
 - python=3.6
 - scikit-image=0.13
-- scikit-learn=0.18
+- scikit-learn=0.19
 - seaborn=0.7
 - tensorflow=1.1
 - sympy=1.0
@@ -26,7 +26,7 @@ dependencies:
 - invoke=0.21
 - xeus-cling=0.4.5
 - xtensor=0.17.0
-- xtensor-blas=0.12
+- xtensor-blas=0.13
 - xwidgets=0.12.2
 - xleaflet=0.2.1
 - r-ggplot2


### PR DESCRIPTION
xtensor-blas 0.12 and scikit-learn 0.18 were causing conflicts, updated versions to 0.13 and 0.19 respectively to resolve this.