### PR TITLE
don't minimize lab build

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -53,7 +53,7 @@ def build(ctx, env_name=env_name, kernel=True):
         jupyter labextension install @jupyter-widgets/jupyterlab-manager@2.0 --no-build &&
         jupyter labextension install bqplot@0.5.6 --no-build &&
         jupyter labextension install jupyter-leaflet@0.12 --no-build &&
-        jupyter lab clean && jupyter lab build --dev-build=False
+        jupyter lab clean && jupyter lab build --dev-build=False --minimize=False
         """.format(source, env_name).strip().replace('\n', ''))
     if kernel:
         ctx.run("{0!s} activate {1!s} && ipython kernel install --name {1!s} --display-name {1!s} --sys-prefix".format(source, env_name))


### PR DESCRIPTION
Binder build containers have a 3G memory limit (recently and temporarily increased from 2G) which is still not enough to complete jupyterlab minimization. I'm not sure how much it needs, but it's too much so jupyterlab minimization always needs to be disabled on Binder until it's a lot less resource intensive.