### PR TITLE
Update to JupyterLab 3.0

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -2,23 +2,23 @@ channels:
 - conda-forge
 dependencies:
 # Jupyter
-- jupyterlab=2
-- nodejs=11
-- nbconvert=5.5
-- widgetsnbextension=3.5
+- jupyterlab=3
+- nodejs=14
+- nbconvert=6
 # Python Kernel
 - ipykernel=5.1
-- ipywidgets=7.5
-- ipyleaflet=0.12
-- altair=3.1
-- bqplot=0.12
-- dask=2.1
-- matplotlib=3.1
-- pandas=0.24
+- xeus-python=0.9
+- ipywidgets=7.6
+# - ipyleaflet=0.12
+# - altair=3.1
+# - bqplot=0.12
+# - dask=2.1
+# - matplotlib=3.1
+- pandas=1
 - python=3.7
 - scikit-image=0.15
 - scikit-learn=0.21
-- seaborn=0.9
+- seaborn=0.11
 - tensorflow=1.13
 - sympy=1.4
 - pyyaml

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -3,6 +3,7 @@ channels:
 dependencies:
 # Jupyter
 - jupyterlab=3
+- jupyter-offlinenotebook=0.2
 - nodejs=12
 - nbconvert=6
 # Python Kernel

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -13,7 +13,7 @@ dependencies:
 - widgetsnbextension=3.5
 - ipyleaflet=0.13
 - altair=4.1
-# - bqplot=0.12
+- bqplot=0.12.20
 - dask=2020.12
 - matplotlib=3.1
 - pandas=1

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -26,11 +26,11 @@ dependencies:
 - traittypes==0.2.1
 - invoke=1.2
 # C++ Kernel
-# - xeus-cling=0.6
+- xeus-cling=0.10
 - xtensor=0.20.8
 - xtensor-blas=0.16.1
-# - xwidgets=0.18.0
-# - xleaflet=0.9.0
+- xwidgets=0.24.2
+- xleaflet=0.13.1
 # R Kernel
 - r-ggplot2
 - r-irkernel=1.0

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -9,11 +9,12 @@ dependencies:
 - ipykernel=5.1
 - xeus-python=0.9
 - ipywidgets=7.6
+- widgetsnbextension=3.5
 # - ipyleaflet=0.12
 # - altair=3.1
 # - bqplot=0.12
 # - dask=2.1
-# - matplotlib=3.1
+- matplotlib=3.1
 - pandas=1
 - python=3.7
 - scikit-image=0.15

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -3,7 +3,7 @@ channels:
 dependencies:
 # Jupyter
 - jupyterlab=3
-- nodejs=14
+- nodejs=12
 - nbconvert=6
 # Python Kernel
 - ipykernel=5.1

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -11,9 +11,9 @@ dependencies:
 - ipywidgets=7.6
 - widgetsnbextension=3.5
 - ipyleaflet=0.13
-# - altair=3.1
+- altair=4.1
 # - bqplot=0.12
-# - dask=2.1
+- dask=2020.12
 - matplotlib=3.1
 - pandas=1
 - python=3.7

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -10,7 +10,7 @@ dependencies:
 - xeus-python=0.9
 - ipywidgets=7.6
 - widgetsnbextension=3.5
-# - ipyleaflet=0.12
+- ipyleaflet=0.13
 # - altair=3.1
 # - bqplot=0.12
 # - dask=2.1

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -28,8 +28,8 @@ dependencies:
 # - xeus-cling=0.6
 - xtensor=0.20.8
 - xtensor-blas=0.16.1
-- xwidgets=0.18.0
-- xleaflet=0.9.0
+# - xwidgets=0.18.0
+# - xleaflet=0.9.0
 # R Kernel
 - r-ggplot2
 - r-irkernel=1.0

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -25,7 +25,7 @@ dependencies:
 - traittypes==0.2.1
 - invoke=1.2
 # C++ Kernel
-- xeus-cling=0.6
+# - xeus-cling=0.6
 - xtensor=0.20.8
 - xtensor-blas=0.16.1
 - xwidgets=0.18.0

--- a/tasks.py
+++ b/tasks.py
@@ -46,14 +46,18 @@ def build(ctx, env_name=env_name, kernel=True):
     '''
     Builds an environment with appropriate extensions.
 
-    TODO: add back when ready
+    TODO: add back when ready:
+    jupyter labextension install @jupyterlab/fasta-extension@2.0 --no-build &&
+    jupyter labextension install @jupyterlab/geojson-extension@2.0 --no-build &&
+
+    TODO: remove explicit jupyter-offlinenotebook install
+    '''
+
     ctx.run("""
         {0!s} activate {1!s} &&
-        jupyter labextension install @jupyterlab/fasta-extension@2.0 --no-build &&
-        jupyter labextension install @jupyterlab/geojson-extension@2.0 --no-build &&
+        jupyter labextension install jupyter-offlinenotebook --no-build &&
         jupyter lab clean && jupyter lab build --dev-build=False --minimize=False
         """.format(source, env_name).strip().replace('\n', ''))
-    '''
     if kernel:
         ctx.run("{0!s} activate {1!s} && ipython kernel install --name {1!s} --display-name {1!s} --sys-prefix".format(source, env_name))
 

--- a/tasks.py
+++ b/tasks.py
@@ -44,17 +44,15 @@ def environment(ctx, clean=False, env_name=env_name):
 @task
 def build(ctx, env_name=env_name, kernel=True):
     '''
-    Builds an environment with appropriate extensions.
-
-    TODO: add back when ready:
-    jupyter labextension install @jupyterlab/fasta-extension@2.0 --no-build &&
-    jupyter labextension install @jupyterlab/geojson-extension@2.0 --no-build &&
+    Builds an environment with appropriate extensions.    
 
     TODO: remove explicit jupyter-offlinenotebook install
     '''
 
     ctx.run("""
         {0!s} activate {1!s} &&
+        jupyter labextension install @jupyterlab/fasta-extension@3.0 --no-build &&
+        jupyter labextension install @jupyterlab/geojson-extension@3.0 --no-build &&
         jupyter labextension install jupyter-offlinenotebook --no-build &&
         jupyter lab clean && jupyter lab build --dev-build=False --minimize=False
         """.format(source, env_name).strip().replace('\n', ''))

--- a/tasks.py
+++ b/tasks.py
@@ -44,9 +44,7 @@ def environment(ctx, clean=False, env_name=env_name):
 @task
 def build(ctx, env_name=env_name, kernel=True):
     '''
-    Builds an environment with appropriate extensions.    
-
-    TODO: remove explicit jupyter-offlinenotebook install
+    Builds an environment with appropriate extensions.
     '''
 
     ctx.run("""

--- a/tasks.py
+++ b/tasks.py
@@ -53,7 +53,6 @@ def build(ctx, env_name=env_name, kernel=True):
         {0!s} activate {1!s} &&
         jupyter labextension install @jupyterlab/fasta-extension@3.0 --no-build &&
         jupyter labextension install @jupyterlab/geojson-extension@3.0 --no-build &&
-        jupyter labextension install jupyter-offlinenotebook --no-build &&
         jupyter lab clean && jupyter lab build --dev-build=False --minimize=False
         """.format(source, env_name).strip().replace('\n', ''))
     if kernel:

--- a/tasks.py
+++ b/tasks.py
@@ -45,16 +45,15 @@ def environment(ctx, clean=False, env_name=env_name):
 def build(ctx, env_name=env_name, kernel=True):
     '''
     Builds an environment with appropriate extensions.
-    '''
+
+    TODO: add back when ready
     ctx.run("""
         {0!s} activate {1!s} &&
         jupyter labextension install @jupyterlab/fasta-extension@2.0 --no-build &&
         jupyter labextension install @jupyterlab/geojson-extension@2.0 --no-build &&
-        jupyter labextension install @jupyter-widgets/jupyterlab-manager@2.0 --no-build &&
-        jupyter labextension install bqplot@0.5.6 --no-build &&
-        jupyter labextension install jupyter-leaflet@0.12 --no-build &&
         jupyter lab clean && jupyter lab build --dev-build=False --minimize=False
         """.format(source, env_name).strip().replace('\n', ''))
+    '''
     if kernel:
         ctx.run("{0!s} activate {1!s} && ipython kernel install --name {1!s} --display-name {1!s} --sys-prefix".format(source, env_name))
 


### PR DESCRIPTION
Replaces https://github.com/jupyterlab/jupyterlab-demo/pull/101

Fixes #100 

For now commenting out some extensions that have not been updated yet.

Can be tested with this link: https://mybinder.org/v2/gh/jupyterlab/jupyterlab-demo/lab3?urlpath=lab

### TODO

- [x] Update to JupyterLab 3.0
- [x] `ipyleaflet`
- [x] `bqplot`
- [x] `jupyterlab-renderers`
- [ ] Check the predefined workspace is correctly restored
