### PR TITLE
Add shebang in `postBuild`

### DIFF
--- a/.binder/postBuild
+++ b/.binder/postBuild
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 set -ex
 
 # invoke r --env-name=notebook


### PR DESCRIPTION
The docs for `postBuild` recommend setting this shebang and link to this file as an example. So maybe it's missing?

https://mybinder.readthedocs.io/en/latest/using/config_files.html#postbuild-run-code-after-installing-the-environment

Feel free to close or merge without comment!